### PR TITLE
Prepare deploy-ready release hardening

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# Get your API key from https://openrouter.ai/
-OPENROUTER_API_KEY="your-openrouter-key-here"

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,26 @@
+# Copy this file to .env for local development.
+
 # Required: OpenRouter API key for agentica LLM calls
 # Get one at https://openrouter.ai/keys
-OPENROUTER_API_KEY=your-openrouter-key-here
+OPENROUTER_API_KEY="your-openrouter-key-here"
 
 # Optional: Direct OpenAI key (if using openai/* models)
-# OPENAI_API_KEY=your-openai-key-here
+# OPENAI_API_KEY="your-openai-key-here"
 
 # Optional: Local platform override
-# LOCAL_PLATFORM_URL=http://localhost:8888/sandbox/inference/v1
-# LOCAL_PLATFORM_API_KEY=your-local-key-here
+# LOCAL_PLATFORM_URL="http://localhost:8888/sandbox/inference/v1"
+# LOCAL_PLATFORM_API_KEY="your-local-key-here"
+
+GMAIL_CREDENTIALS_PATH="./credentials.json"
+SLACK_BOT_TOKEN="xoxb-your-token"
+SLACK_APP_TOKEN="xapp-your-token"
+
+# Runtime configuration
+ACM_ENV="development"
+ACM_DB_PATH=""
+ACM_CORS_ORIGINS="http://localhost:5173,http://127.0.0.1:5173"
+ACM_MUTATION_API_KEY=""
+ACM_HAS_WRITE_SCOPE="false"
+ACM_ENABLE_DOCS="true"
+ACM_RELEASE_VERSION="0.1.0"
+ACM_BUILD_SHA=""

--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,15 @@ wheels/
 
 # Virtual environments
 .venv
-
-# Environment secrets
 .env
+.env.*
+.envrc
+!.env.example
+!.env.sample
+!.env.template
 
-# Agentica logs
+# Local runtime artifacts
+data/
 logs_agent/
 logs_runtime/
 .gstack/

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ OPENROUTER_API_KEY=your_openrouter_key
 GMAIL_CREDENTIALS_PATH=./credentials.json
 SLACK_BOT_TOKEN=xoxb-your-token
 SLACK_APP_TOKEN=xapp-your-token
+ACM_ENV=development
+ACM_CORS_ORIGINS=http://localhost:5173
 ```
 
 ### Run
@@ -118,12 +120,27 @@ SLACK_APP_TOKEN=xapp-your-token
 uv run python main.py
 ```
 
+### API Server
+
+```bash
+uv run uvicorn emailmanagement.api:app --reload
+```
+
+Health checks:
+
+```bash
+curl http://127.0.0.1:8000/health/live
+curl http://127.0.0.1:8000/health/ready
+```
+
 ---
 
 ## Project Documents
 
 - [`PRD.md`](./PRD.md) — Full Product Requirements Document
 - [`agentica-mini/README.md`](./agentica-mini/README.md) — Agent framework documentation
+- [`docs/OPERATIONS.md`](./docs/OPERATIONS.md) — Deploy, auth, health-check, and rollback guide
+- [`SECURITY.md`](./SECURITY.md) — Vulnerability reporting and security baseline
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,43 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+This repository is still pre-1.0. Only the latest commit on `master` receives security fixes.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version | Supported |
+| --- | --- |
+| `0.1.x` | Yes |
+| `< 0.1.0` | No |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Do not open a public GitHub issue for a suspected security issue.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Use one of these private paths instead:
+
+1. GitHub private vulnerability reporting for this repository, if enabled.
+2. Direct private contact with the repository maintainer through the same channel used to grant repo access.
+
+Include:
+
+- a short description of the issue
+- the affected file, endpoint, or workflow
+- reproduction steps
+- impact and any known workaround
+
+### Response targets
+
+- Initial acknowledgement: within 3 business days
+- Triage decision: within 7 business days
+- Status updates: at least weekly until resolved or declined
+
+### Disclosure policy
+
+- Please keep the report private until a fix ships or the maintainer confirms the issue is not actionable.
+- If credentials may have leaked, rotate them immediately and note the exposure window in the report.
+
+## Security baselines
+
+- Production secrets must come from environment variables or a secret manager, never tracked files.
+- `.env` is local-only. Use `.env.example` for templates.
+- Mutating API routes should require `X-ACM-API-Key` in deployed environments.
+- `/health/live` and `/health/ready` must pass before a release is considered healthy.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,83 @@
+# Operations Guide
+
+## Production Baseline
+
+This project now supports a basic production split between local development and deployed environments.
+
+### Runtime configuration
+
+Set configuration through environment variables only.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `ACM_ENV` | Runtime mode: `development`, `staging`, `production` | `development` |
+| `ACM_DB_PATH` | SQLite database path | temp dir in dev, `./data/acm_api_state.db` in staging/prod |
+| `ACM_CORS_ORIGINS` | Comma-separated allowed browser origins | `http://localhost:5173` |
+| `ACM_MUTATION_API_KEY` | Required for state-changing API routes when set | unset |
+| `ACM_HAS_WRITE_SCOPE` | Enables live write actions when true | `false` |
+| `ACM_ENABLE_DOCS` | Enables `/docs` and `/openapi.json` | true in dev, false in prod |
+| `ACM_RELEASE_VERSION` | Human-readable release version | `0.1.0` |
+| `ACM_BUILD_SHA` | Build or git SHA surfaced in readiness | unset |
+
+Copy `.env.example` to `.env` for local development. Do not commit `.env`.
+
+## Auth model
+
+The app is still prototype-grade, so the auth model is intentionally narrow and explicit.
+
+### Current model
+
+- `GET` routes are read-only and intended for internal dashboards or trusted networks.
+- Mutating routes must be protected with `X-ACM-API-Key` when `ACM_MUTATION_API_KEY` is set.
+- Live side effects stay disabled unless `ACM_HAS_WRITE_SCOPE=true`.
+
+### Recommended deployment model
+
+1. Put the API behind your platform auth layer or private network.
+2. Require `X-ACM-API-Key` for mutating routes.
+3. Keep `ACM_HAS_WRITE_SCOPE=false` until Gmail and Slack write flows are end-to-end verified.
+4. Add user-level OAuth only when a real operator dashboard exists.
+
+## Health checks
+
+Use these endpoints in deploy orchestration.
+
+- `GET /health/live` checks that the process is up.
+- `GET /health/ready` checks that SQLite is reachable and returns deploy metadata.
+
+Recommended checks:
+
+```bash
+curl -fsS http://127.0.0.1:8000/health/live
+curl -fsS http://127.0.0.1:8000/health/ready
+```
+
+Treat readiness as the gate for rollout completion.
+
+## Deployment checklist
+
+1. `uv sync`
+2. `uv run pytest`
+3. `cd frontend && npm install && npm run lint && npm run build`
+4. Set `ACM_ENV=production`
+5. Set `ACM_CORS_ORIGINS` to the real frontend origin
+6. Set `ACM_MUTATION_API_KEY` to a secret value stored in the deploy platform
+7. Keep `ACM_ENABLE_DOCS=false`
+8. Verify `/health/live` and `/health/ready`
+
+## Rollback path
+
+This app does not have database migrations yet, so rollback is simple.
+
+1. Re-deploy the previous application image or commit.
+2. Keep the same `ACM_DB_PATH` and secrets.
+3. Re-run `/health/ready`.
+4. If the new release wrote bad state, restore the SQLite file from the last backup snapshot.
+
+Recommended operational rule: take a file-level backup of `ACM_DB_PATH` before every production deploy.
+
+## Logging and secrets
+
+- Never commit `.env`.
+- Do not store production secrets in repo files.
+- Agent runtime logs may contain prompt and model output content. Keep `logs_agent/` and `logs_runtime/` off persistent shared disks unless log redaction is added.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1898,27 +1898,6 @@
         "path-browserify": "^1.0.1"
       }
     },
-    "node_modules/@ts-morph/common/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -1932,6 +1911,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2209,9 +2204,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2530,7 +2525,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,5 +36,8 @@
     "globals": "^17.4.0",
     "tailwindcss": "^4.2.2",
     "vite": "^8.0.1"
+  },
+  "overrides": {
+    "brace-expansion": "1.1.13"
   }
 }

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,13 +1,25 @@
+import { useState } from "react";
 import { Outlet } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import TopBar from "./TopBar";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 
 export default function Layout() {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
   return (
     <div className="min-h-screen bg-surface text-on-surface font-body selection:bg-primary/30 antialiased">
       <Sidebar />
-      <TopBar />
-      <main className="ml-64 mt-14 p-8">
+      <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+        <SheetContent
+          side="left"
+          className="w-[88vw] max-w-xs border-surface-container-high bg-surface p-0 text-on-surface"
+        >
+          <Sidebar mobile onNavigate={() => setMobileNavOpen(false)} />
+        </SheetContent>
+      </Sheet>
+      <TopBar onOpenMobileNav={() => setMobileNavOpen(true)} />
+      <main className="px-4 pb-6 pt-20 md:ml-64 md:mt-14 md:p-8">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,12 +1,21 @@
+import { useState } from "react";
 import { NavLink } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Bot, Plus, Inbox, BarChart3, Contact, HelpCircle, FileText } from "lucide-react";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
-export default function Sidebar() {
+export default function Sidebar({ mobile = false, onNavigate = () => {} }) {
+  const [supportOpen, setSupportOpen] = useState(false);
+  const [docsOpen, setDocsOpen] = useState(false);
+
+  const shellClassName = mobile
+    ? "flex h-full flex-col bg-surface p-4 text-sm"
+    : "fixed left-0 top-0 z-50 hidden h-screen w-64 flex-col bg-surface p-4 text-sm antialiased md:flex";
+
   return (
-    <aside className="h-screen w-64 fixed left-0 top-0 bg-surface font-['Inter'] antialiased tracking-tight text-sm flex flex-col p-4 z-50">
+    <aside className={shellClassName}>
       <div className="mb-6 px-2 flex items-center gap-3">
         <div className="w-8 h-8 rounded-sm bg-primary-container flex items-center justify-center text-on-primary-container">
           <Bot size={20} />
@@ -24,15 +33,15 @@ export default function Sidebar() {
 
       <ScrollArea className="flex-1 -mx-4 px-4">
         <nav className="space-y-1">
-          <NavLink to="/queue" className={({isActive}) => `flex items-center gap-3 px-3 py-2 rounded-sm font-medium transition-colors duration-150 ${isActive ? 'text-on-surface bg-surface-container-high' : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high'}`}>
+          <NavLink onClick={onNavigate} to="/queue" className={({isActive}) => `flex items-center gap-3 px-3 py-2 rounded-sm font-medium transition-colors duration-150 ${isActive ? 'text-on-surface bg-surface-container-high' : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high'}`}>
             <Inbox size={20} />
             Queue
           </NavLink>
-          <NavLink to="/metrics" className={({isActive}) => `flex items-center gap-3 px-3 py-2 rounded-sm font-medium transition-colors duration-150 ${isActive ? 'text-on-surface bg-surface-container-high' : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high'}`}>
+          <NavLink onClick={onNavigate} to="/metrics" className={({isActive}) => `flex items-center gap-3 px-3 py-2 rounded-sm font-medium transition-colors duration-150 ${isActive ? 'text-on-surface bg-surface-container-high' : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high'}`}>
             <BarChart3 size={20} />
             Analytics
           </NavLink>
-          <NavLink to="/contacts" className={({isActive}) => `flex items-center gap-3 px-3 py-2 rounded-sm font-medium transition-colors duration-150 ${isActive ? 'text-on-surface bg-surface-container-high' : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high'}`}>
+          <NavLink onClick={onNavigate} to="/contacts" className={({isActive}) => `flex items-center gap-3 px-3 py-2 rounded-sm font-medium transition-colors duration-150 ${isActive ? 'text-on-surface bg-surface-container-high' : 'text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high'}`}>
             <Contact size={20} />
             Contacts
           </NavLink>
@@ -41,13 +50,75 @@ export default function Sidebar() {
       
       <div className="pt-4 space-y-1 mt-auto">
         <Separator className="bg-surface-container-high mb-4" />
-        <a className="flex items-center gap-3 px-3 py-2 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors duration-150 rounded-sm" href="#">
+        <button
+          className="flex w-full items-center gap-3 rounded-sm px-3 py-2 text-left text-on-surface-variant transition-colors duration-150 hover:bg-surface-container-high hover:text-on-surface"
+          onClick={() => setSupportOpen(true)}
+          type="button"
+        >
           <HelpCircle size={20} /> Support
-        </a>
-        <a className="flex items-center gap-3 px-3 py-2 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors duration-150 rounded-sm" href="#">
+        </button>
+        <button
+          className="flex w-full items-center gap-3 rounded-sm px-3 py-2 text-left text-on-surface-variant transition-colors duration-150 hover:bg-surface-container-high hover:text-on-surface"
+          onClick={() => setDocsOpen(true)}
+          type="button"
+        >
           <FileText size={20} /> Docs
-        </a>
+        </button>
       </div>
+
+      <Dialog open={supportOpen} onOpenChange={setSupportOpen}>
+        <DialogContent className="bg-surface border border-surface-container-high text-on-surface">
+          <DialogHeader>
+            <DialogTitle>Support</DialogTitle>
+            <DialogDescription className="text-on-surface-variant">
+              Need help with a triage workflow? Start with the docs, then contact the ops owner.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 text-sm text-on-surface-variant">
+            <p>Primary contact: `support@autonomous-manager.local`</p>
+            <p>Escalation: Queue issues, delivery failures, or approval mistakes go to the support channel first.</p>
+          </div>
+          <DialogFooter className="bg-surface-container-low/60">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setSupportOpen(false);
+                setDocsOpen(true);
+              }}
+            >
+              Open Docs
+            </Button>
+            <Button onClick={() => setSupportOpen(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={docsOpen} onOpenChange={setDocsOpen}>
+        <DialogContent className="bg-surface border border-surface-container-high text-on-surface">
+          <DialogHeader>
+            <DialogTitle>Docs</DialogTitle>
+            <DialogDescription className="text-on-surface-variant">
+              Quick references for this prototype.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 text-sm text-on-surface-variant">
+            <p>Frontend: `npm run dev` in `frontend/`</p>
+            <p>API docs: `http://127.0.0.1:8000/docs`</p>
+            <p>Core routes: Queue, Analytics, Contacts</p>
+          </div>
+          <DialogFooter className="bg-surface-container-low/60">
+            <a
+              className="group/button inline-flex h-8 shrink-0 items-center justify-center rounded-lg border border-border bg-background px-2.5 text-sm font-medium text-on-surface transition-all hover:bg-muted hover:text-foreground"
+              href="http://127.0.0.1:8000/docs"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Open API Docs
+            </a>
+            <Button onClick={() => setDocsOpen(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </aside>
   );
 }

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -1,27 +1,36 @@
-import { Search, Bell, ChevronDown } from "lucide-react";
+import { Menu, Search, Bell, ChevronDown } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 
-export default function TopBar() {
+export default function TopBar({ onOpenMobileNav }) {
   return (
-    <header className="fixed top-0 right-0 left-64 h-14 z-40 bg-surface/80 backdrop-blur-xl flex items-center justify-between px-6 border-b border-surface-container-high">
-      <div className="flex items-center">
-        <span className="text-sm font-black text-on-surface mr-8">AUTONOMOUS AI</span>
-        <div className="flex items-center bg-surface-container-lowest px-3 py-1.5 rounded-sm w-64 group border border-transparent focus-within:border-primary/20 transition-all">
+    <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center justify-between border-b border-surface-container-high bg-surface/80 px-4 backdrop-blur-xl md:left-64 md:px-6">
+      <div className="flex items-center gap-3 md:gap-0">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface md:hidden"
+          onClick={onOpenMobileNav}
+        >
+          <Menu className="h-4 w-4" />
+          <span className="sr-only">Open navigation</span>
+        </Button>
+        <span className="mr-0 text-sm font-black text-on-surface md:mr-8">AUTONOMOUS AI</span>
+        <div className="group hidden w-64 items-center rounded-sm border border-transparent bg-surface-container-lowest px-3 py-1.5 transition-all focus-within:border-primary/20 sm:flex">
           <Search className="text-on-surface-variant w-3.5 h-3.5 mr-2" />
           <input className="bg-transparent border-none outline-none focus:ring-0 text-xs w-full text-on-surface p-0 placeholder:text-outline/50" placeholder="Quick Search" type="text"/>
           <span className="text-[10px] text-outline/40 font-mono">⌘K</span>
         </div>
       </div>
 
-      <div className="flex items-center space-x-6">
-        <nav className="flex space-x-6 font-['Inter'] text-xs font-medium uppercase tracking-widest">
+      <div className="flex items-center gap-3 md:gap-6">
+        <nav className="hidden space-x-6 font-['Inter'] text-xs font-medium uppercase tracking-widest lg:flex">
           <a className="text-on-surface-variant hover:text-on-surface transition-all" href="#">Workspace</a>
           <a className="text-primary-container border-b border-primary-container pb-1" href="#">Agent Active</a>
         </nav>
         
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center gap-2 md:gap-4">
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger
@@ -35,12 +44,12 @@ export default function TopBar() {
             </Tooltip>
           </TooltipProvider>
           
-          <div className="flex items-center gap-2 bg-surface-container-high pl-1 pr-3 py-1 rounded-full active:scale-[0.98] transition-all cursor-pointer">
+          <div className="flex cursor-pointer items-center gap-2 rounded-full bg-surface-container-high py-1 pl-1 pr-2 transition-all active:scale-[0.98] md:pr-3">
             <Avatar className="w-6 h-6">
               <AvatarImage src="https://lh3.googleusercontent.com/aida-public/AB6AXuCYxyplhPAPwqnOqpmNiQ4-PeRuRuw7hoSn3KDf2XB-Z_upQgks_FbH0PPm9JVED_zgEXlE3eWk6MIV87YfVGiFFMfgUlwBfwMBSRtqlYW0frYrzLgIORqmoS0JAnXKl-JDqXqGXf67AB1aDspNUkM-2WelrYvbi-BGxv2dBfVeI27eJwcVq5NtGwkMLVgPhOnFka69vUVv-XW1Df__hln3ctQmZkNkGSOC1gAt-2HGu_1qUbyk2WvrNfMCK3mWeYVu3Ri02En3HkQ-" alt="user avatar"/>
               <AvatarFallback className="text-[10px] bg-primary text-on-primary">DV</AvatarFallback>
             </Avatar>
-            <span className="text-[10px] font-bold text-on-surface">DR. VECTOR</span>
+            <span className="hidden text-[10px] font-bold text-on-surface sm:inline">DR. VECTOR</span>
             <ChevronDown className="w-3 h-3 text-on-surface-variant" />
           </div>
         </div>

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -46,4 +46,4 @@ function Badge({
   });
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -54,4 +54,4 @@ function Button({
   );
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/frontend/src/components/ui/tabs.jsx
+++ b/frontend/src/components/ui/tabs.jsx
@@ -76,4 +76,4 @@ function TabsContent({
   );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/frontend/src/views/Dashboard.jsx
+++ b/frontend/src/views/Dashboard.jsx
@@ -6,20 +6,64 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 
+const fallbackActivity = [
+  { id: "fallback-1", decision: "urgent", reason: "Investor email identified, flagged for review", timestamp: Date.now() / 1000, is_reversible: true },
+  { id: "fallback-2", decision: "archive", reason: "Dependabot alert archived, no action needed", timestamp: Date.now() / 1000 - 240, is_reversible: true },
+  { id: "fallback-3", decision: "normal", reason: "Sales inquiry drafted for pricing review", timestamp: Date.now() / 1000 - 900, is_reversible: true },
+];
+
+const decisionStyles = {
+  urgent: "HIGH",
+  archive: "LOW",
+  normal: "MED",
+  low: "LOW",
+};
+
+const badgeStyles = {
+  HIGH: "bg-error-container/30 text-error",
+  MED: "bg-secondary-container/30 text-secondary",
+  LOW: "bg-surface-container-highest text-on-surface-variant",
+};
+
+function formatTimestamp(timestamp) {
+  return new Date(timestamp * 1000).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
 export default function Dashboard() {
   const [metrics, setMetrics] = useState(null);
   const [queue, setQueue] = useState(null);
+  const [activity, setActivity] = useState(null);
   const [loading, setLoading] = useState(true);
   const [itemToApprove, setItemToApprove] = useState(null);
+  const [draftItem, setDraftItem] = useState(null);
+  const [draftText, setDraftText] = useState("");
+  const [savedDrafts, setSavedDrafts] = useState({});
+
+  const openDraftEditor = (item) => {
+    setDraftItem(item);
+    setDraftText(savedDrafts[item.id] ?? `Reply to ${item.recipient} about ${item.title}.`);
+  };
+
+  const closeDraftEditor = () => {
+    setDraftItem(null);
+    setDraftText("");
+  };
 
   useEffect(() => {
     Promise.all([
       fetch("/api/metrics").then(r => r.json()),
-      fetch("/api/queue").then(r => r.json())
+      fetch("/api/queue").then(r => r.json()),
+      fetch("/api/activity").then(r => r.json()),
     ])
-    .then(([metricsData, queueData]) => {
+    .then(([metricsData, queueData, activityData]) => {
       setMetrics(metricsData);
       setQueue(queueData);
+      setActivity(activityData);
       setLoading(false);
     })
     .catch(err => {
@@ -29,6 +73,7 @@ export default function Dashboard() {
         { id: 1, type: "slack", recipient: "#support", title: "Urgent: API Down", score: 98, one_line_summary: "Customer reporting 500 errors on checkout", snippet: "..." },
         { id: 2, type: "email", recipient: "sales@example.com", title: "Enterprise Pricing", score: 85, one_line_summary: "Inquiry about 500+ seat license", snippet: "..." }
       ]);
+      setActivity(fallbackActivity);
       setLoading(false);
     });
   }, []);
@@ -36,13 +81,28 @@ export default function Dashboard() {
   const handleApprove = async () => {
     if (!itemToApprove) return;
     try {
-      await fetch(`/api/queue/${itemToApprove}/approve`, { method: 'POST' });
+      const response = await fetch(`/api/queue/${itemToApprove}/approve`, { method: 'POST' });
+      const data = await response.json();
+
       setQueue(q => q.filter(item => item.id !== itemToApprove));
       setMetrics(prev => ({ ...prev, handled_total: prev.handled_total + 1 }));
+      if (data.action) {
+        setActivity(prev => [data.action, ...(prev ?? [])]);
+      }
       setItemToApprove(null);
     } catch (e) {
       console.error(e);
     }
+  };
+
+  const handleSaveDraft = () => {
+    if (!draftItem) return;
+
+    setSavedDrafts((current) => ({
+      ...current,
+      [draftItem.id]: draftText,
+    }));
+    closeDraftEditor();
   };
 
   return (
@@ -132,9 +192,9 @@ export default function Dashboard() {
         </Card>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Pending Approvals */}
-        <div className="lg:col-span-2 space-y-4">
+       <div className="grid grid-cols-1 gap-8 xl:grid-cols-3">
+         {/* Pending Approvals */}
+         <div className="space-y-4 xl:col-span-2">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-sm font-bold uppercase tracking-[0.15em] flex items-center gap-2">
               <ShieldCheck className="text-primary w-5 h-5" /> Pending Approvals
@@ -168,11 +228,16 @@ export default function Dashboard() {
                     </div>
                     <div className="text-[10px] font-mono text-outline">Score: {item.score}</div>
                   </div>
-                  <div className="bg-surface-container-lowest p-3 rounded-sm text-xs font-mono text-on-surface-variant mb-4 leading-relaxed line-clamp-2 font-bold">
-                    {item.one_line_summary || item.snippet || "No summary available"}
-                  </div>
-                  <div className="flex gap-2">
-                    <Dialog>
+                     <div className="bg-surface-container-lowest p-3 rounded-sm text-xs font-mono text-on-surface-variant mb-4 leading-relaxed line-clamp-2 font-bold">
+                       {item.one_line_summary || item.snippet || "No summary available"}
+                     </div>
+                     {savedDrafts[item.id] && (
+                       <div className="mb-4 rounded-sm border border-primary/20 bg-primary/8 px-3 py-2 text-[10px] font-mono text-primary">
+                         Draft updated and ready to review.
+                       </div>
+                     )}
+                     <div className="flex gap-2">
+                       <Dialog>
                       <DialogTrigger
                         render={<Button variant="outline" className="flex-1 bg-primary/10 hover:bg-primary/20 text-primary border-none text-[10px] font-bold uppercase tracking-widest rounded-sm" />}
                         onClick={() => setItemToApprove(item.id)}
@@ -191,11 +256,11 @@ export default function Dashboard() {
                           <Button variant="default" className="bg-primary text-on-primary hover:bg-primary/90" onClick={handleApprove}>Confirm & Send</Button>
                         </DialogFooter>
                       </DialogContent>
-                    </Dialog>
-                    <Button variant="secondary" className="px-4 bg-surface-container-highest hover:bg-surface-variant text-on-surface border-none text-[10px] font-bold uppercase tracking-widest rounded-sm">
-                      Edit Draft
-                    </Button>
-                  </div>
+                       </Dialog>
+                      <Button onClick={() => openDraftEditor(item)} variant="secondary" className="px-4 bg-surface-container-highest hover:bg-surface-variant text-on-surface border-none text-[10px] font-bold uppercase tracking-widest rounded-sm">
+                        Edit Draft
+                      </Button>
+                     </div>
                 </CardContent>
               </Card>
             ))}
@@ -209,39 +274,65 @@ export default function Dashboard() {
               <History className="text-tertiary w-5 h-5" /> Recent Activity
             </h3>
           </div>
-          <Card className="bg-surface-container-low rounded-sm border-none overflow-hidden">
-            <CardContent className="p-0 divide-y divide-[#1c1c1c]">
-              <div className="p-4 hover:bg-surface-container-high transition-colors">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-[10px] font-mono text-tertiary">14:22:01</span>
-                  <Badge className="text-[10px] px-1.5 py-0 rounded-sm bg-error-container/30 text-error font-bold border-none">HIGH</Badge>
-                </div>
-                <p className="text-xs font-medium text-on-surface mb-1">Triage: Support Slack</p>
-                <p className="text-[10px] text-on-surface-variant line-clamp-1">Auto-assigned to Critical Engineering team.</p>
-              </div>
-              <div className="p-4 hover:bg-surface-container-high transition-colors">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-[10px] font-mono text-on-surface-variant">14:18:45</span>
-                  <Badge variant="secondary" className="text-[10px] px-1.5 py-0 rounded-sm bg-surface-container-highest text-on-surface-variant font-bold border-none">LOW</Badge>
-                </div>
-                <p className="text-xs font-medium text-on-surface mb-1">Triage: GitHub Notification</p>
-                <p className="text-[10px] text-on-surface-variant line-clamp-1">Dependabot alert archived - No action needed.</p>
-              </div>
-              <div className="p-4 hover:bg-surface-container-high transition-colors">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-[10px] font-mono text-on-surface-variant">14:05:12</span>
-                  <Badge className="text-[10px] px-1.5 py-0 rounded-sm bg-secondary-container/30 text-secondary font-bold border-none">MED</Badge>
-                </div>
-                <p className="text-xs font-medium text-on-surface mb-1">Triage: Sales Email</p>
-                <p className="text-[10px] text-on-surface-variant line-clamp-1">Drafted custom response for pricing inquiry.</p>
-              </div>
-            </CardContent>
-          </Card>
+           <Card className="bg-surface-container-low rounded-sm border-none overflow-hidden">
+             <CardContent className="p-0 divide-y divide-[#1c1c1c]">
+               {loading ? (
+                 <div className="space-y-3 p-4">
+                   <Skeleton className="h-16 w-full bg-surface-container-high rounded-sm" />
+                   <Skeleton className="h-16 w-full bg-surface-container-high rounded-sm" />
+                   <Skeleton className="h-16 w-full bg-surface-container-high rounded-sm" />
+                 </div>
+               ) : activity?.map((action) => {
+                 const severity = decisionStyles[action.decision] || "MED";
+
+                 return (
+                   <div key={action.id} className="p-4 hover:bg-surface-container-high transition-colors">
+                     <div className="flex items-center justify-between mb-1 gap-2">
+                       <span className="text-[10px] font-mono text-on-surface-variant">{formatTimestamp(action.timestamp)}</span>
+                       <Badge className={`text-[10px] px-1.5 py-0 rounded-sm font-bold border-none ${badgeStyles[severity]}`}>
+                         {severity}
+                       </Badge>
+                     </div>
+                     <p className="text-xs font-medium text-on-surface mb-1">Triage: {action.decision}</p>
+                     <p className="text-[10px] text-on-surface-variant line-clamp-2">{action.reason}</p>
+                   </div>
+                 );
+               })}
+             </CardContent>
+           </Card>
           <Button variant="ghost" className="w-full py-2 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant hover:text-on-surface hover:bg-transparent transition-colors flex items-center justify-center gap-2">
             View Full Audit Log <ArrowRight className="w-4 h-4" />
           </Button>
         </div>
       </div>
+
+      <Dialog open={Boolean(draftItem)} onOpenChange={(open) => !open && closeDraftEditor()}>
+        <DialogContent className="max-w-xl bg-surface border border-surface-container-high text-on-surface">
+          <DialogHeader>
+            <DialogTitle>Edit Draft</DialogTitle>
+            <DialogDescription className="text-on-surface-variant">
+              Review the outbound message before an operator approves it.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="rounded-sm border border-surface-container-high bg-surface-container-low px-3 py-2 text-[10px] font-mono text-on-surface-variant">
+              {draftItem?.recipient} · {draftItem?.title}
+            </div>
+            <textarea
+              className="min-h-40 w-full rounded-sm border border-surface-container-high bg-surface-container-low p-3 text-sm text-on-surface outline-none transition focus:border-primary/40"
+              onChange={(event) => setDraftText(event.target.value)}
+              placeholder="Draft a response..."
+              value={draftText}
+            />
+          </div>
+          <DialogFooter className="bg-surface-container-low/60">
+            <Button variant="outline" onClick={closeDraftEditor}>
+              Cancel
+            </Button>
+            <Button onClick={handleSaveDraft}>Save Draft</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/emailmanagement/api.py
+++ b/src/emailmanagement/api.py
@@ -146,12 +146,31 @@ def get_queue():
 def approve_queue_item(item_id: int):
     """Approve a queued item by ID."""
     global queue_items
-    original_len = len(queue_items)
-    queue_items = [item for item in queue_items if item["id"] != item_id]
-    if len(queue_items) == original_len:
+    approved_item = next((item for item in queue_items if item["id"] == item_id), None)
+    if approved_item is None:
         raise HTTPException(status_code=404, detail=f"Queue item {item_id} not found")
+
+    queue_items = [item for item in queue_items if item["id"] != item_id]
     metrics.record_automated_decision()
-    return {"success": True}
+    action = AgentAction(
+        id=str(uuid.uuid4()),
+        event_id=str(item_id),
+        decision="normal",
+        reason=f"Approved {approved_item['type']} message for {approved_item['recipient']}",
+        timestamp=time.time(),
+        is_reversible=True,
+    )
+    feed._recent_actions.insert(0, action)
+    return {
+        "success": True,
+        "action": {
+            "id": action.id,
+            "decision": action.decision,
+            "reason": action.reason,
+            "timestamp": action.timestamp,
+            "is_reversible": action.is_reversible,
+        },
+    }
 
 
 @app.get("/api/contacts")

--- a/src/emailmanagement/api.py
+++ b/src/emailmanagement/api.py
@@ -1,31 +1,37 @@
 """FastAPI server for the Autonomous Communication Manager."""
 
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
-
-from emailmanagement.metrics import MetricsTracker
-from emailmanagement.activity_feed import ActivityFeed, AgentAction
-from emailmanagement.contact_graph import ContactGraph, ContactNode, RelationshipClass
-from emailmanagement.persistence import SqliteStore
-from emailmanagement.action_executor import ActionExecutor, ExecutionRequest, ActionType
-from emailmanagement.draft_generator import DraftGenerator, DraftReply
-from emailmanagement.debounce import IncomingEvent
-
+import os
+import secrets
 import time
 import uuid
 
-import tempfile
-import os
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.middleware.cors import CORSMiddleware
+
+from emailmanagement.action_executor import ActionExecutor
+from emailmanagement.activity_feed import ActivityFeed, AgentAction
+from emailmanagement.contact_graph import ContactGraph, ContactNode, RelationshipClass
+from emailmanagement.debounce import IncomingEvent
+from emailmanagement.draft_generator import DraftGenerator
+from emailmanagement.metrics import MetricsTracker
+from emailmanagement.persistence import SqliteStore
+from emailmanagement.settings import AppSettings
 
 # ---------------------------------------------------------------------------
 # Module-level instances (initialized on import)
 # ---------------------------------------------------------------------------
-_db_path = os.path.join(tempfile.gettempdir(), "acm_api_state.db")
+settings = AppSettings.from_env()
+
+_db_dir = os.path.dirname(settings.db_path)
+if _db_dir:
+    os.makedirs(_db_dir, exist_ok=True)
+
+_db_path = settings.db_path
 store = SqliteStore(_db_path)
 metrics = MetricsTracker()
 feed = ActivityFeed()
 graph = ContactGraph(store=store)
-executor = ActionExecutor(store=store, has_write_scope=False)
+executor = ActionExecutor(store=store, has_write_scope=settings.has_write_scope)
 
 # DraftGenerator — wired when an agentica agent is available (see /api/draft endpoint)
 _draft_generator: DraftGenerator | None = None
@@ -109,15 +115,66 @@ queue_items: list[dict] = [
 # ---------------------------------------------------------------------------
 # App
 # ---------------------------------------------------------------------------
-app = FastAPI(title="Autonomous Communication Manager")
+app = FastAPI(
+    title="Autonomous Communication Manager",
+    version=settings.release_version,
+    docs_url="/docs" if settings.docs_enabled else None,
+    redoc_url="/redoc" if settings.docs_enabled else None,
+    openapi_url="/openapi.json" if settings.docs_enabled else None,
+)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_origins=list(settings.cors_origins),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def require_mutation_auth(request: Request) -> None:
+    if not settings.requires_api_key:
+        return
+
+    provided = request.headers.get("x-acm-api-key")
+    expected = settings.mutation_api_key or ""
+    if not provided or not secrets.compare_digest(provided, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid mutation API key",
+        )
+
+
+@app.get("/health/live")
+def liveness_probe():
+    return {
+        "status": "ok",
+        "service": "acm-api",
+        "environment": settings.environment,
+        "version": settings.release_version,
+    }
+
+
+@app.get("/health/ready")
+def readiness_probe():
+    try:
+        with store._get_connection() as conn:
+            conn.execute("SELECT 1")
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Database unavailable: {exc}",
+        ) from exc
+
+    return {
+        "status": "ready",
+        "service": "acm-api",
+        "environment": settings.environment,
+        "auth_mode": settings.auth_mode,
+        "write_scope": settings.has_write_scope,
+        "build_sha": settings.build_sha,
+        "db_path": settings.db_path,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -143,8 +200,9 @@ def get_queue():
 
 
 @app.post("/api/queue/{item_id}/approve")
-def approve_queue_item(item_id: int):
+def approve_queue_item(item_id: int, request: Request):
     """Approve a queued item by ID."""
+    require_mutation_auth(request)
     global queue_items
     approved_item = next((item for item in queue_items if item["id"] == item_id), None)
     if approved_item is None:

--- a/src/emailmanagement/settings.py
+++ b/src/emailmanagement/settings.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+
+
+def _parse_csv(value: str | None, default: tuple[str, ...]) -> tuple[str, ...]:
+    if value is None:
+        return default
+
+    items = tuple(part.strip() for part in value.split(",") if part.strip())
+    return items or default
+
+
+@dataclass(frozen=True)
+class AppSettings:
+    environment: str
+    db_path: str
+    cors_origins: tuple[str, ...]
+    mutation_api_key: str | None
+    has_write_scope: bool
+    docs_enabled: bool
+    release_version: str
+    build_sha: str | None
+
+    @property
+    def requires_api_key(self) -> bool:
+        return bool(self.mutation_api_key)
+
+    @property
+    def auth_mode(self) -> str:
+        return "x-acm-api-key" if self.requires_api_key else "none"
+
+    @classmethod
+    def from_env(cls) -> "AppSettings":
+        environment = (
+            os.getenv("ACM_ENV", "development").strip().lower() or "development"
+        )
+        default_db_path = os.path.join(tempfile.gettempdir(), "acm_api_state.db")
+        if environment in {"staging", "production"}:
+            default_db_path = os.path.join(os.getcwd(), "data", "acm_api_state.db")
+
+        cors_default = ("http://localhost:5173",)
+        docs_default = environment != "production"
+
+        return cls(
+            environment=environment,
+            db_path=os.getenv("ACM_DB_PATH", default_db_path),
+            cors_origins=_parse_csv(os.getenv("ACM_CORS_ORIGINS"), cors_default),
+            mutation_api_key=os.getenv("ACM_MUTATION_API_KEY") or None,
+            has_write_scope=os.getenv("ACM_HAS_WRITE_SCOPE", "false").lower() == "true",
+            docs_enabled=os.getenv("ACM_ENABLE_DOCS", str(docs_default).lower()).lower()
+            == "true",
+            release_version=os.getenv("ACM_RELEASE_VERSION", "0.1.0"),
+            build_sha=os.getenv("ACM_BUILD_SHA") or None,
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,6 +84,37 @@ def test_approve_returns_success(client):
     assert response.json()["success"] is True
 
 
+def test_approve_returns_activity_action_and_feed_updates(client):
+    # Regression: ISSUE-003 — queue approvals did not show up in recent activity
+    # Found by /qa on 2026-03-28
+    # Report: .gstack/qa-reports/qa-report-127-0-0-1-2026-03-28.md
+    from emailmanagement import api
+
+    api.queue_items = [
+        {
+            "id": 42,
+            "type": "slack",
+            "recipient": "#support",
+            "title": "Escalated incident",
+            "score": 97,
+            "one_line_summary": "Customer reports new checkout failures",
+        }
+    ]
+    baseline_actions = len(api.feed.get_recent_actions())
+
+    response = client.post("/api/queue/42/approve")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["action"]["decision"] == "normal"
+    assert data["action"]["reason"] == "Approved slack message for #support"
+
+    actions = client.get("/api/activity").json()
+    assert actions[0]["reason"] == "Approved slack message for #support"
+    assert len(api.feed.get_recent_actions()) == baseline_actions + 1
+
+
 def test_approve_removes_item_from_queue(client):
     client.post("/api/queue/2/approve")
     ids = [item["id"] for item in client.get("/api/queue").json()]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Tests for the FastAPI server (api.py)."""
 
+import importlib
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -37,6 +39,21 @@ def test_docs_endpoint_returns_html(client):
     response = client.get("/docs")
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
+
+
+def test_liveness_probe_returns_ok(client):
+    response = client.get("/health/live")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_readiness_probe_returns_ready(client):
+    response = client.get("/health/ready")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ready"
+    assert "auth_mode" in data
+    assert "write_scope" in data
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +141,29 @@ def test_approve_removes_item_from_queue(client):
 def test_approve_nonexistent_returns_404(client):
     response = client.post("/api/queue/9999/approve")
     assert response.status_code == 404
+
+
+def test_approve_requires_api_key_when_configured(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACM_MUTATION_API_KEY", "release-key")
+    monkeypatch.setenv("ACM_DB_PATH", str(tmp_path / "auth.db"))
+
+    import emailmanagement.api as api_module
+
+    reloaded = importlib.reload(api_module)
+    client = TestClient(reloaded.app)
+
+    unauthorized = client.post("/api/queue/1/approve")
+    assert unauthorized.status_code == 401
+
+    authorized = client.post(
+        "/api/queue/1/approve",
+        headers={"x-acm-api-key": "release-key"},
+    )
+    assert authorized.status_code == 200
+
+    monkeypatch.delenv("ACM_MUTATION_API_KEY", raising=False)
+    monkeypatch.delenv("ACM_DB_PATH", raising=False)
+    importlib.reload(api_module)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,39 @@
+from emailmanagement.settings import AppSettings
+
+
+def test_settings_default_to_local_dev_values(monkeypatch):
+    monkeypatch.delenv("ACM_ENV", raising=False)
+    monkeypatch.delenv("ACM_DB_PATH", raising=False)
+    monkeypatch.delenv("ACM_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("ACM_MUTATION_API_KEY", raising=False)
+
+    settings = AppSettings.from_env()
+
+    assert settings.environment == "development"
+    assert settings.docs_enabled is True
+    assert settings.auth_mode == "none"
+    assert settings.cors_origins == ("http://localhost:5173",)
+
+
+def test_settings_enable_prod_auth_and_disable_docs(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACM_ENV", "production")
+    monkeypatch.setenv("ACM_DB_PATH", str(tmp_path / "prod.db"))
+    monkeypatch.setenv(
+        "ACM_CORS_ORIGINS", "https://app.example.com,https://ops.example.com"
+    )
+    monkeypatch.setenv("ACM_MUTATION_API_KEY", "prod-secret")
+    monkeypatch.setenv("ACM_ENABLE_DOCS", "false")
+    monkeypatch.setenv("ACM_HAS_WRITE_SCOPE", "true")
+
+    settings = AppSettings.from_env()
+
+    assert settings.environment == "production"
+    assert settings.db_path == str(tmp_path / "prod.db")
+    assert settings.cors_origins == (
+        "https://app.example.com",
+        "https://ops.example.com",
+    )
+    assert settings.requires_api_key is True
+    assert settings.auth_mode == "x-acm-api-key"
+    assert settings.docs_enabled is False
+    assert settings.has_write_scope is True


### PR DESCRIPTION
## Summary
- restore queue workflows and mobile dashboard usability so the app is stable enough to operate and review on real screens
- harden runtime configuration for deployment with `.env.example`, environment-based API settings, optional mutation API-key auth, and liveness/readiness endpoints
- document the operational baseline in `README.md`, `SECURITY.md`, and `docs/OPERATIONS.md`, including deploy, rollback, and secret-handling guidance
- patch the frontend `brace-expansion` advisory and remove unused shadcn variant exports so lint and build stay clean

## Verification
- `uv run pytest`
- `frontend npm run lint`
- `frontend npm run build`
- `frontend npm audit --json`
- `uv run --with pip-audit pip-audit` *(still reports `pygments 2.19.2`, no published upstream fix available yet)*

## Notes
- this branch was rebuilt on top of `origin/master` after review found the original PR was based on a stale local `master`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden API for production deployment with health checks, auth, and environment-driven config
> - Adds `AppSettings` dataclass in [settings.py](https://github.com/rznies/autonomous-communication-manager/pull/42/files#diff-8f9d78e03a346cbfe68d6830255665c4c82025fb5bd349579b3eccfa08bf9e8f) to drive DB path, CORS origins, API key, docs visibility, and write scope from environment variables
> - Adds `/health/live` and `/health/ready` endpoints; the readiness probe verifies SQLite connectivity and returns deploy metadata (env, build SHA, auth mode)
> - Adds `require_mutation_auth` to enforce an `x-acm-api-key` header on mutating routes when `ACM_MUTATION_API_KEY` is set; `POST /api/queue/{item_id}/approve` now returns a structured action object and records it to the activity feed
> - Adds mobile-responsive navigation to the frontend: a slide-in sidebar drawer on small screens, toggled from the `TopBar`; `Dashboard` fetches recent activity from `/api/activity` and supports draft editing in a modal
> - Removes `.env` from the repo, updates `.gitignore` to exclude all `.env.*` files, and adds `SECURITY.md` and `docs/OPERATIONS.md` with deployment and secrets guidance
> - Risk: `ACM_ENABLE_DOCS=false` hides OpenAPI docs in production; existing callers relying on `/docs` or unauthenticated mutating endpoints will break if the new env vars are configured
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 90872ff. 16 files reviewed, 4 issues evaluated, 1 issue filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>tests/test_api.py — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 162](https://github.com/rznies/autonomous-communication-manager/blob/90872ffaadbd915f75b4b2cf2a3ee375e7bf4f8b/tests/test_api.py#L162): The authorized request on line 162 expects status code 200, but since `ACM_DB_PATH` is set to a fresh `tmp_path` directory, the reloaded module likely initializes with an empty database/queue. Queue item 1 may not exist in this fresh state, causing the endpoint to return 404 (as demonstrated by `test_approve_nonexistent_returns_404`) rather than the expected 200. The test needs to either populate the queue with item 1 after reload, or use an item ID that's guaranteed to exist. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->